### PR TITLE
Added proper typing for `getRecording`

### DIFF
--- a/react-record-webcam/package.json
+++ b/react-record-webcam/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-record-webcam",
   "description": "A React webcam recording hook and component 🎬📹",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/react-record-webcam/src/hook/index.ts
+++ b/react-record-webcam/src/hook/index.ts
@@ -11,7 +11,7 @@ export type UseRecordWebcam = {
   webcamRef: React.RefObject<HTMLVideoElement>;
   close: () => void;
   download: () => void;
-  getRecording: () => void;
+  getRecording: () => Promise<Blob | null>;
   open: () => void;
   retake: () => void;
   start: () => void;
@@ -137,17 +137,16 @@ export function useRecordWebcam(options?: RecordOptions): UseRecordWebcam {
     }
   };
 
-  const getRecording = async () => {
+  const getRecording = (): Promise<Blob | null> => {
     try {
       if (recorder?.getBlob) {
-        const blob = await recorder.getBlob();
-        return blob;
+        return recorder.getBlob();
       }
-      return null;
+      return Promise.resolve(null);
     } catch (error) {
       setStatus('ERROR');
       console.error({ error });
-      return null;
+      return Promise.reject(error);
     }
   };
 


### PR DESCRIPTION
The typing for `getRecording` is not correct, it should return a `Promise` with the `Blob`

Also bumped version to 0.0.18